### PR TITLE
expose remote debug port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,9 @@ FROM openjdk:alpine
 
 COPY --from=BUILDQ /usr/src/myapp/target/*.jar /maven/
 
-CMD java -agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n -jar maven/*.jar
+# set debug=true to get spring boot debug-level logging
+ENV debug=false
+# set REMOTE_DEBUG=true to enable connections to remote debug port
+ENV REMOTE_DEBUG=false
+
+CMD if [ "x$REMOTE_DEBUG" = "xfalse" ] ; then java -jar maven/*.jar ; else java -agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n -jar maven/*.jar ; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ FROM openjdk:alpine
 
 COPY --from=BUILDQ /usr/src/myapp/target/*.jar /maven/
 
-CMD java -jar maven/*.jar
+CMD java -agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n -jar maven/*.jar


### PR DESCRIPTION
See issue https://github.com/Activiti/Activiti/issues/1412 for more context.

This sets up port 8000 as the remote debug port. You can then use to connect to the java process running in the container provided the port is mapped. To test this I had to add these lines to the activiti-cloud-query section of the infrastructure docker-compose:

      - REMOTE_DEBUG=true
    ports:
      - "8000:8000"

But I've not done a PR for that as I don't think it should be exposed by default (it seems to slow startup if set). When I did it locally I was able to debug by putting debug points on the source inside dependent libraries of the activiti-cloud-query app:

<img width="1539" alt="screen shot 2017-08-25 at 17 20 03" src="https://user-images.githubusercontent.com/22754674/29722888-6f2a8d74-89ba-11e7-99c7-14856159f3d6.png">

(IntelliJ config is as per https://stackoverflow.com/questions/21114066/attach-intellij-idea-debugger-to-a-running-java-process but 8000 instead of 5005.)

If the arg is not set then query and audit register with eureka at around the same time. If it is set then query registers noticeably later. So should only set it if need to debug.

In the process of doing this realised we could also expose setting ' - debug = true' to enable spring boot debug logging so also exposing that in this PR (again default is off).
