### PR TITLE
Update copyright header 

### DIFF
--- a/src/main/java/org/actviti/cloud/query/QueryApplication.java
+++ b/src/main/java/org/actviti/cloud/query/QueryApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- since a new year started the copyright year was updated to 2018

[#1686](https://github.com/Activiti/Activiti/issues/1686)