### PR TITLE
feat: make updatebot push cloud dependencies version for validation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,8 +32,8 @@ pipeline {
             sh "mvn install"
             sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
-//           skip building docker image for now
-   //        sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            // skip building docker image for now
+            // sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
 
 
              dir("./charts/$APP_NAME") {
@@ -81,9 +81,9 @@ pipeline {
               sh 'make release'
               sh 'make github'  
               // promote through all 'Auto' promotion Environments
-//            sh 'jx promote -b --all-auto --timeout 1h --version \$(cat ../../VERSION) --no-wait'
+              // sh 'jx promote -b --all-auto --timeout 1h --version \$(cat ../../VERSION) --no-wait'
               sh 'jx step git credentials'
-              sh 'cd ../.. && updatebot push-version --kind helm $APP_NAME \$(cat VERSION)'
+              sh 'make updatebot/push-version'
 
             }
           }

--- a/charts/activiti-cloud-query/Makefile
+++ b/charts/activiti-cloud-query/Makefile
@@ -1,8 +1,10 @@
 #CHART_REPO := http://jenkins-x-chartmuseum:8080
-CURRENT=$(pwd)
+CURRENT=$(shell pwd)
 NAME := activiti-cloud-query
+APP_NAME := $(or $(APP_NAME),$(NAME))
 OS := $(shell uname)
 RELEASE_VERSION := $(shell cat ../../VERSION)
+RELEASE_ARTIFACT := $(or $(RELEASE_ARTIFACT),$(APP_NAME))
 
 GITHUB_CHARTS_REPO := $(or $(GITHUB_CHARTS_REPO),$(shell git config --get remote.origin.url))
 GITHUB_CHARTS_BRANCH := $(or $(GITHUB_CHARTS_BRANCH),gh-pages)
@@ -52,7 +54,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)/activiti/activiti-cloud-query|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)/$(ORG)/$(APP_NAME)|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"
@@ -62,3 +64,11 @@ endif
 	git commit -m "release $(RELEASE_VERSION)" --allow-empty # if first release then no verion update is performed
 	git tag -fa v$(RELEASE_VERSION) -m "Release version $(RELEASE_VERSION)"
 	git push origin v$(RELEASE_VERSION)
+
+updatebot/push-version: 
+	@echo Resolving push versions for artifacts........
+	$(eval ACTIVITI_CLOUD_DEPENDENCIES_VERSION=$(shell mvn help:evaluate -Dexpression=activiti-cloud-dependencies.version -q -DforceStdout))
+	
+	@echo Doing updatebot push-version.....
+	updatebot push-version --kind helm $(RELEASE_ARTIFACT) $(RELEASE_VERSION)
+	updatebot push-version --kind make QUERY_ACTIVITI_CLOUD_DEPENDENCIES_VERSION $(ACTIVITI_CLOUD_DEPENDENCIES_VERSION)

--- a/charts/activiti-cloud-query/Makefile
+++ b/charts/activiti-cloud-query/Makefile
@@ -1,6 +1,7 @@
 #CHART_REPO := http://jenkins-x-chartmuseum:8080
 CURRENT=$(shell pwd)
 NAME := activiti-cloud-query
+ORG := $(or $(ORG),activiti)
 APP_NAME := $(or $(APP_NAME),$(NAME))
 OS := $(shell uname)
 RELEASE_VERSION := $(shell cat ../../VERSION)


### PR DESCRIPTION
into downstream activiti-cloud-application-chart repo, so, that we can validate same activiti-cloud-dependencies for all microservices  in Jenkins CI/CD pipeline before building and releasing the chart.

Part of Activiti/Activiti#2264