### PR TITLE
fix(chart): disabled db and postgresql auto ddl values

### DIFF
--- a/charts/activiti-cloud-query/values.yaml
+++ b/charts/activiti-cloud-query/values.yaml
@@ -28,8 +28,8 @@ db:
   password:
   driver:
   platform:
-  generateDdl:
-  ddlAuto:
+  generateDdl: "false"
+  ddlAuto: "none"
 init:
   image:
     repository: alpine
@@ -41,6 +41,8 @@ postgres:
   port: 5432
   username: postgres
   password:
+  generateDdl: "false"
+  ddlAuto: "none"
 
 javaOpts:
   xmx: 2048m


### PR DESCRIPTION
This PR fixes conflict between Liquibase and Hibernate auto generating DDL and updating Db schema settings.