### PR TITLE
refactor(build): removed  duplicate security keycloak module 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,6 @@
       <artifactId>activiti-cloud-starter-query</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.activiti.cloud.common</groupId>
-      <artifactId>activiti-cloud-services-common-security-keycloak</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>


### PR DESCRIPTION
This PR fixes Spring Boot bean override problems by removing component scans from configuration classes and adds missing @ConditionalOnMissingBean annotation on beans created in Activiti Runtime Spring Boot Auto-configurations

Depends on https://github.com/Activiti/activiti-cloud-query-service/pull/307

Fixes https://github.com/Activiti/Activiti/issues/1399